### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ appropriate function:
 
 ```elixir
 defmodule ModuleThatNeedsMetrics do
-   use Instruments
+  use Instruments
 
   def other_function() do
     Process.sleep(150)


### PR DESCRIPTION
This PR fixes extra space typo in `README.md` file. It doesn't change any code or business rule.