### PR TITLE
Fixes a disagreement between the behaviour and the calling code.

### DIFF
--- a/lib/probe.ex
+++ b/lib/probe.ex
@@ -74,7 +74,7 @@ defmodule Instruments.Probe do
   You must return `{:ok, state}`. Any other return values will cancel further
   execution of the probe.
   """
-  @callback probe_handle_msg(any, state) :: {:ok, state}
+  @callback probe_handle_message(any, state) :: {:ok, state}
 
   alias Instruments.Probe.Definitions
 

--- a/lib/probe/function.ex
+++ b/lib/probe/function.ex
@@ -26,5 +26,5 @@ defmodule Instruments.Probe.Function do
     {:ok, {probe_fn, probe_value}}
   end
 
-  def probe_handle_msg(_, state), do: {:ok, state}
+  def probe_handle_message(_, state), do: {:ok, state}
 end

--- a/lib/probes/schedulers.ex
+++ b/lib/probes/schedulers.ex
@@ -75,7 +75,7 @@ defmodule Instruments.Probes.Schedulers do
   end
 
   @doc false
-  def probe_handle_msg(_, state), do: {:ok, state}
+  def probe_handle_message(_, state), do: {:ok, state}
 
   # end probe behaviour callbacks
 

--- a/test/probe/probe_test.exs
+++ b/test/probe/probe_test.exs
@@ -167,24 +167,50 @@ defmodule Instruments.ProbeTest do
 
   describe "probes in a module" do
     defmodule ModuleProbe do
+      @behaviour Instruments.Probe
+
+      @impl Instruments.Probe
       def probe_init(_name, _type, _opts), do: {:ok, 0}
+
+      @impl Instruments.Probe
       def probe_get_value(state), do: {:ok, state}
+
+      @impl Instruments.Probe
       def probe_reset(_), do: {:ok, 0}
+
+      @impl Instruments.Probe
       def probe_sample(state), do: {:ok, state + 1}
+
+      @impl Instruments.Probe
       def probe_handle_message(_msg, state), do: {:ok, state}
+
       def probe_get_datapoints(_), do: [:foo]
     end
 
     defmodule MessageProbe do
+      @behaviour Instruments.Probe
+
+      @impl Instruments.Probe
       def probe_init(_name, _type, _opts), do: {:ok, 1}
+
+      @impl Instruments.Probe
       def probe_get_value(state), do: {:ok, state}
+
+      @impl Instruments.Probe
       def probe_reset(_), do: {:ok, 0}
+
+      @impl Instruments.Probe
       def probe_sample(state) do
         send(self(), {:do_update, 6})
         {:ok, state}
       end
+
+      @impl Instruments.Probe
       def probe_handle_message({:do_update, val}, _state), do: {:ok, val}
+
+      @impl Instruments.Probe
       def probe_handle_message(_msg, state), do: {:ok, state}
+
       def probe_get_datapoints(_), do: [:foo]
     end
 


### PR DESCRIPTION
The calling code (see `Instruments.Probe.Runner.handle_info/2`) calls
`probe_handle_message/2`.

Any modules in the wild that rely on the runner dispatching the message
must implement the undocumented `probe_handle_message/2` instead of
`probe_handle_msg/2` and either stub that function or ignore the
warning.

Given this reasoning, the behaviour's contract was updated to specify
the function being called, this may result in new warnings for modules
that implemented the old contract but should not break any modules that
actual rely on message being dispatched correctly.

Instances in the library that use `probe_handle_msg/2` were updated to
use the correct `probe_handle_message/2`, both instances were stubs.

The tests were updated so that the test probe modules declare that they
are implementing the Instruments.Probe behaviour.