### PR TITLE
Add host config option

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -4,8 +4,9 @@ use Mix.Config
 # in test so we don't conflict in the build env.
 config :instruments,
   statsd_port: 15310,
+  statsd_host: "localhost",
   fast_counter_report_interval: 10,
   reporter_module: Instruments.Statix
 
 config :logger, compile_time_purge_level: :error, level: :error#, backends: []
-config :statix, port: 15310
+config :statix, port: 15310, host: "localhost"

--- a/lib/instruments.ex
+++ b/lib/instruments.ex
@@ -56,6 +56,7 @@ defmodule Instruments do
 
   @metrics_module Application.get_env(:instruments, :reporter_module, Instruments.Statix)
   @statsd_port Application.get_env(:instruments, :statsd_port, 8125)
+  @statsd_host to_charlist(Application.get_env(:instruments, :statsd_host, "localhost"))
 
   defmacro __using__(_opts) do
     quote do
@@ -65,6 +66,9 @@ defmodule Instruments do
 
   @doc false
   def statsd_port(), do: @statsd_port
+
+  @doc false
+  def statsd_host(), do: @statsd_host
 
   # metrics macros
   @doc false
@@ -176,7 +180,7 @@ defmodule Instruments do
       # this will have to be changed.
       unquote(@metrics_module)
       |> Process.whereis
-      |> :gen_udp.send('localhost', Instruments.statsd_port(), message)
+      |> :gen_udp.send(Instruments.statsd_host(), Instruments.statsd_port(), message)
     end
   end
 

--- a/pages/Configuration.md
+++ b/pages/Configuration.md
@@ -26,7 +26,9 @@ There are a couple of `Instruments` specific application variables:
 * `fast_counter_report_interval`: How often counters should send data to the `reporter_module`. Defaults
                                   to 10 seconds.
 * `probe_prefix`: A global prefix to apply to all probes.
-* `statsd_port`: The port that the statsd server listens on. Should be the same as the port in the statix 
+* `statsd_port`: The port that the statsd server listens on. Should be the same as the port in the statix
+                 configuration above.
+* `statsd_host`: The host that the statsd server listens on. Should be the same as the host in the statix
                  configuration above.
 
 For example:
@@ -35,4 +37,5 @@ For example:
        reporter_module: Instruments.StatsReporter.Logger,
        fast_counter_report_interval: 30_000,
        probe_prefix: "probes",
-       statsd_port: 15339
+       statsd_port: 15339,
+       statsd_host: "localhost"


### PR DESCRIPTION
Statsd doesn't necessarily run on the same host, so it would be useful to be able to specify `host`, just like `statix` lets you. 