### PR TITLE
Don't crash when a probe receives undefined

### DIFF
--- a/lib/probe/runner.ex
+++ b/lib/probe/runner.ex
@@ -132,6 +132,9 @@ defmodule Instruments.Probe.Runner do
           send_metric(metric_name, value, state)
         end)
 
+      :undefined ->
+        Logger.info "Not Sending #{state.name} due to :undefined return"
+        
       nil ->
         Logger.info "Not Sending #{state.name} due to nil return"
     end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Instruments.Mixfile do
   use Mix.Project
 
-  @version "1.1.1"
+  @version "1.1.2"
   @github_url "https://github.com/discordapp/instruments"
 
   def project do


### PR DESCRIPTION
I noticed my service is crashing from time to time because a probe gets an "undefined" value.
It looks like the prob is configured to call ETS.info(:size), which the erlang docs say can return :undefined.  Since most services probably have this problem, figured it's best to just drop :undefined like we would nil in the probe.