### PR TITLE
update statix dep for fork with otp26 fix

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule Instruments.Mixfile do
       {:benchee, "~> 1.4", only: :dev},
       {:ex_doc, "~> 0.28", only: :dev, runtime: false},
       {:recon, "~> 2.5.2"},
-      {:statix, "~> 1.2.1"},
+      {:statix, github: "discord/statix", ref: "ca65308681bfece1de12e4156aa1cf1e4a512e59"},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -12,5 +12,5 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "recon": {:hex, :recon, "2.5.2", "cba53fa8db83ad968c9a652e09c3ed7ddcc4da434f27c3eaa9ca47ffb2b1ff03", [:mix, :rebar3], [], "hexpm", "2c7523c8dee91dff41f6b3d63cba2bd49eb6d2fe5bf1eec0df7f87eb5e230e1c"},
   "statistex": {:hex, :statistex, "1.1.0", "7fec1eb2f580a0d2c1a05ed27396a084ab064a40cfc84246dbfb0c72a5c761e5", [:mix], [], "hexpm", "f5950ea26ad43246ba2cce54324ac394a4e7408fdcf98b8e230f503a0cba9cf5"},
-  "statix": {:hex, :statix, "1.2.1", "4f23c8cc2477ea0de89fed5e34f08c54b0d28b838f7b8f26613155f2221bb31e", [:mix], [], "hexpm", "7f988988fddcce19ae376bb8e47aa5ea5dabf8d4ba78d34d1ae61eb537daf72e"},
+  "statix": {:git, "https://github.com/discord/statix.git", "ca65308681bfece1de12e4156aa1cf1e4a512e59", [ref: "ca65308681bfece1de12e4156aa1cf1e4a512e59"]},
 }


### PR DESCRIPTION
The Statix usage of `Port.command` for UDP sending breaks in OTP26. Update the instruments statix dep to point at the Cabify fork. 

This fork matches the Statix we were on with the following fix: https://github.com/cabify/statix/pull/1

Unfortunately the main Statix project looks dormant according to this: https://github.com/lexmag/statix/issues/69