### PR TITLE
Use Statix-based event sending

### DIFF
--- a/lib/instruments.ex
+++ b/lib/instruments.ex
@@ -175,35 +175,7 @@ defmodule Instruments do
     title_iodata = MacroHelpers.to_iolist(title_ast, __CALLER__)
 
     quote do
-      title = unquote(title_iodata)
-
-      header = [
-        "_e{",
-        Integer.to_charlist(IO.iodata_length(title)),
-        ",",
-        Integer.to_charlist(IO.iodata_length(unquote(text))),
-        "}:",
-        title,
-        "|",
-        unquote(text)
-      ]
-
-      message =
-        case Keyword.get(unquote(opts), :tags) do
-          nil ->
-            header
-
-          tag_list ->
-            [header, "|#", Enum.intersperse(tag_list, ",")]
-        end
-
-      # Statix registers a port to the name of the metrics module.
-      # and this code assumes that the metrics module is bound to
-      # a port, and sends directly to it. If we move off of Statix,
-      # this will have to be changed.
-      unquote(@metrics_module)
-      |> Process.whereis()
-      |> :gen_udp.send('localhost', Instruments.statsd_port(), message)
+      unquote(@metrics_module).send_event(unquote(title_iodata), unquote(text), unquote(opts))
     end
   end
 

--- a/lib/stats_reporter.ex
+++ b/lib/stats_reporter.ex
@@ -52,4 +52,11 @@ defmodule Instruments.StatsReporter do
   Write the value into the set defined by `key`
   """
   @callback set(key, integer, keyword) :: stats_return
+
+  @doc """
+  Send a DataDog event with the given title and text
+  """
+  @callback send_event(title :: iodata, text :: iodata, keyword) :: stats_return
+
+  @optional_callbacks [send_event: 3]
 end

--- a/lib/stats_reporter/logger.ex
+++ b/lib/stats_reporter/logger.ex
@@ -45,4 +45,9 @@ defmodule Instruments.StatsReporter.Logger do
   def set(key, value, _options \\ []) do
     Logger.info("setting #{key} to #{value}")
   end
+
+  @doc false
+  def send_event(title, text, _options \\ []) do
+    Logger.info("event #{title}: #{text}")
+  end
 end

--- a/lib/stats_reporter/null.ex
+++ b/lib/stats_reporter/null.ex
@@ -28,4 +28,7 @@ defmodule Instruments.StatsReporter.Null do
 
   @doc false
   def set(_key, _value, _options \\ []), do: :ok
+
+  @doc false
+  def send_event(_title, _text, _options \\ []), do: :ok
 end

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule Instruments.Mixfile do
       {:benchee, "~> 1.4", only: :dev},
       {:ex_doc, "~> 0.28", only: :dev, runtime: false},
       {:recon, "~> 2.5.2"},
-      {:statix, "~> 1.7.0", hex: :discord_statix},
+      {:statix, "~> 1.8.0", hex: :discord_statix},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -12,5 +12,5 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "recon": {:hex, :recon, "2.5.2", "cba53fa8db83ad968c9a652e09c3ed7ddcc4da434f27c3eaa9ca47ffb2b1ff03", [:mix, :rebar3], [], "hexpm", "2c7523c8dee91dff41f6b3d63cba2bd49eb6d2fe5bf1eec0df7f87eb5e230e1c"},
   "statistex": {:hex, :statistex, "1.1.0", "7fec1eb2f580a0d2c1a05ed27396a084ab064a40cfc84246dbfb0c72a5c761e5", [:mix], [], "hexpm", "f5950ea26ad43246ba2cce54324ac394a4e7408fdcf98b8e230f503a0cba9cf5"},
-  "statix": {:hex, :discord_statix, "1.7.0", "f84140caed09177da1952bef3f92eb9b94a1acc8c2de0b7826bf7a6002c017b6", [:mix], [], "hexpm", "3c316994c334d4d41d45cb5e2a67efb399327c4de5e65f01e52ab61eefd7eed9"},
+  "statix": {:hex, :discord_statix, "1.8.0", "11a5daa60029b39cfab2e11f7158bb1be3a426a9349731145184c3e257bd820a", [:mix], [], "hexpm", "a840f9c2f5789986830cb259e50947c5263c09eaf8c1662b9511f28e772a7acd"},
 }


### PR DESCRIPTION
This requires https://github.com/discord/statix/pull/11 to merge. You can find more info about the problem this solves in that PR, but TL;DR, we want to support the Unix Domain Socket layer that Statix provides us.

This will need a bump to `mix.exs` in order to to pull in the published version of Statix once that is ready.