### PR TITLE
Add probe for per-allocator statistics

### DIFF
--- a/lib/instruments.ex
+++ b/lib/instruments.ex
@@ -238,6 +238,20 @@ defmodule Instruments do
         report_interval: report_interval
       )
 
+      Probe.define!(
+        "recon.alloc.allocated",
+        :gauge,
+        module: Probes.Allocators,
+        keys: ~w(
+          by_allocator
+          mseg_alloc_carriers_size
+          sys_alloc_carriers_size
+          mseg_alloc_carriers
+          sys_alloc_carriers
+        )a,
+        report_interval: report_interval
+      )
+
       cond do
         # The supercarrier is part of mseg_alloc (the flags are all under +MMsc*, where the second "M" refers to `mseg_alloc`)
         # https://www.erlang.org/doc/apps/erts/erts_alloc.html

--- a/lib/instruments.ex
+++ b/lib/instruments.ex
@@ -244,10 +244,8 @@ defmodule Instruments do
         module: Probes.Allocators,
         keys: ~w(
           by_allocator
-          mseg_alloc_carriers_size
-          sys_alloc_carriers_size
-          mseg_alloc_carriers
-          sys_alloc_carriers
+          backing_carriers
+          backing_carriers_size
         )a,
         report_interval: report_interval
       )
@@ -260,24 +258,29 @@ defmodule Instruments do
             function: fn ->
               erts_mmap_info = :erlang.system_info({:allocator, :erts_mmap})
 
-              get_in(erts_mmap_info, [:default_mmap, :supercarrier, :sizes]) || [total: 0, used: 0]
+              get_in(erts_mmap_info, [:default_mmap, :supercarrier, :sizes]) ||
+                [total: 0, used: 0]
             end,
             keys: ~w(total used)a,
             report_interval: report_interval
           )
 
         Application.get_env(:instruments, :warn_on_memory_stats_unsupported?, true) ->
-          Logger.warn("[Instruments] not collecting memory metrics because :mseg_alloc is not enabled")
+          Logger.warn(
+            "[Instruments] not collecting memory metrics because :mseg_alloc is not enabled"
+          )
 
-        true -> :ok
+        true ->
+          :ok
       end
     rescue
       ErlangError ->
         if Application.get_env(:instruments, :warn_on_memory_stats_unsupported?, true) do
-          Logger.warn("[Instruments] not collecting memory metrics because :erlang.memory is unsupported (some allocator disabled?)")
+          Logger.warn(
+            "[Instruments] not collecting memory metrics because :erlang.memory is unsupported (some allocator disabled?)"
+          )
         end
     end
-
 
     # process_count = current number of processes.
     # port_count = current number of ports.

--- a/lib/probes/allocators.ex
+++ b/lib/probes/allocators.ex
@@ -92,9 +92,9 @@ defmodule Instruments.Probes.Allocators do
   defp compute_sum(item, stat_name) do
     case item do
       {^stat_name, value} -> value
-      # Technically these last two branches aren't used for the keys in
-      # @carrier_stats, but I have left them so we can extend that list as
-      # needed.
+      # The 3-tuple branch isn't currently exercised by the keys in
+      # @backing_allocators, but it's left here so the list can be extended as
+      # needed. (The 4-tuple branch is used by the *_carriers_size stats.)
       {^stat_name, value, _} -> value
       {^stat_name, value, _, _} -> value
       _other -> 0

--- a/lib/probes/allocators.ex
+++ b/lib/probes/allocators.ex
@@ -2,15 +2,16 @@ defmodule Instruments.Probes.Allocators do
   @moduledoc """
   A probe that reports per-allocator memory statistics.
 
-  This probe reports five metrics, all derived from `:recon_alloc`:
+  This probe reports three metrics, all derived from `:recon_alloc`:
 
-    * `by_allocator`: the memory used by each allocated type, as reported by
+    * `by_allocator`: the memory allocated by each allocator, as reported by
       `:recon_alloc.memory(:allocated_types)`. A single metric is emitted per
       allocator, tagged with `allocator:<name>`.
-    * `mseg_alloc_carriers_size`, `sys_alloc_carriers_size`,
-      `mseg_alloc_carriers`, `sys_alloc_carriers`: the sum of the corresponding
-      carrier statistic across every allocator instance reported by
-      `:recon_alloc.allocators/0`.
+    * `backing_carriers`, `backing_carriers_size`: the number of carriers (and
+      their total size) allocated by each backing allocator, summed across every
+      allocator instance reported by `:recon_alloc.allocators/0`. One metric is
+      emitted per backing allocator, tagged with `allocator:<name>` (one of
+      `mseg_alloc` or `sys_alloc`).
 
   To use this probe, register it with the matching keys:
 
@@ -19,25 +20,18 @@ defmodule Instruments.Probes.Allocators do
         module: Probes.Allocators,
         keys: ~w(
           by_allocator
-          mseg_alloc_carriers_size
-          sys_alloc_carriers_size
-          mseg_alloc_carriers
-          sys_alloc_carriers
+          backing_carriers
+          backing_carriers_size
         )a
       )
 
-  All five keys are then reported under `recon.alloc.allocated.<key>`.
+  All three keys are then reported under `recon.alloc.allocated.<key>`.
   """
   alias Instruments.Probe
 
   @behaviour Probe
 
-  @carrier_stats ~w(
-    mseg_alloc_carriers_size
-    sys_alloc_carriers_size
-    mseg_alloc_carriers
-    sys_alloc_carriers
-  )a
+  @backing_allocators ~w(mseg_alloc sys_alloc)a
 
   # Probe behaviour callbacks
 
@@ -49,7 +43,7 @@ defmodule Instruments.Probes.Allocators do
 
   @doc false
   def probe_get_value(_state) do
-    {:ok, by_allocator_values() ++ carrier_sum_values()}
+    {:ok, by_allocator_values() ++ backing_carrier_values()}
   end
 
   @doc false
@@ -71,11 +65,16 @@ defmodule Instruments.Probes.Allocators do
     )
   end
 
-  defp carrier_sum_values() do
+  defp backing_carrier_values() do
     allocator_infos = Enum.map(:recon_alloc.allocators(), fn {{_name, _}, info} -> info end)
 
-    for stat_name <- @carrier_stats do
-      {stat_name, compute_sum(allocator_infos, stat_name)}
+    for backing <- @backing_allocators,
+        {key, stat_name} <- [
+          backing_carriers: :"#{backing}_carriers",
+          backing_carriers_size: :"#{backing}_carriers_size"
+        ] do
+      sum = compute_sum(allocator_infos, stat_name)
+      {key, Probe.Value.new(sum, tags: ["allocator:#{backing}"])}
     end
   end
 

--- a/lib/probes/allocators.ex
+++ b/lib/probes/allocators.ex
@@ -1,0 +1,104 @@
+defmodule Instruments.Probes.Allocators do
+  @moduledoc """
+  A probe that reports per-allocator memory statistics.
+
+  This probe reports five metrics, all derived from `:recon_alloc`:
+
+    * `by_allocator`: the memory used by each allocated type, as reported by
+      `:recon_alloc.memory(:allocated_types)`. A single metric is emitted per
+      allocator, tagged with `allocator:<name>`.
+    * `mseg_alloc_carriers_size`, `sys_alloc_carriers_size`,
+      `mseg_alloc_carriers`, `sys_alloc_carriers`: the sum of the corresponding
+      carrier statistic across every allocator instance reported by
+      `:recon_alloc.allocators/0`.
+
+  To use this probe, register it with the matching keys:
+
+      alias Instruments.{Probe, Probes}
+      Probe.define!("recon.alloc.allocated", :gauge,
+        module: Probes.Allocators,
+        keys: ~w(
+          by_allocator
+          mseg_alloc_carriers_size
+          sys_alloc_carriers_size
+          mseg_alloc_carriers
+          sys_alloc_carriers
+        )a
+      )
+
+  All five keys are then reported under `recon.alloc.allocated.<key>`.
+  """
+  alias Instruments.Probe
+
+  @behaviour Probe
+
+  @carrier_stats ~w(
+    mseg_alloc_carriers_size
+    sys_alloc_carriers_size
+    mseg_alloc_carriers
+    sys_alloc_carriers
+  )a
+
+  # Probe behaviour callbacks
+
+  @doc false
+  def probe_init(_name, _type, _options), do: {:ok, nil}
+
+  @doc false
+  def probe_sample(state), do: {:ok, state}
+
+  @doc false
+  def probe_get_value(_state) do
+    {:ok, by_allocator_values() ++ carrier_sum_values()}
+  end
+
+  @doc false
+  def probe_reset(state), do: {:ok, state}
+
+  @doc false
+  def probe_handle_message(_, state), do: {:ok, state}
+
+  # end probe behaviour callbacks
+
+  # Private
+
+  defp by_allocator_values() do
+    Enum.map(
+      :recon_alloc.memory(:allocated_types),
+      fn {allocator, size} ->
+        {:by_allocator, Probe.Value.new(size, tags: ["allocator:#{allocator}"])}
+      end
+    )
+  end
+
+  defp carrier_sum_values() do
+    allocator_infos = Enum.map(:recon_alloc.allocators(), fn {{_name, _}, info} -> info end)
+
+    for stat_name <- @carrier_stats do
+      {stat_name, compute_sum(allocator_infos, stat_name)}
+    end
+  end
+
+  # sums all items with the specified stat name (from all groups).
+  defp compute_sum(items, stat_name) when is_list(items) do
+    items
+    |> Enum.map(fn item -> compute_sum(item, stat_name) end)
+    |> Enum.sum()
+  end
+
+  defp compute_sum({_group, items}, stat_name) when is_list(items) do
+    compute_sum(items, stat_name)
+  end
+
+  defp compute_sum(item, stat_name) do
+    case item do
+      {^stat_name, value} -> value
+      # Technically these last two branches aren't used for the keys in
+      # @carrier_stats, but I have left them so we can extend that list as
+      # needed.
+      {^stat_name, value, _} -> value
+      {^stat_name, value, _, _} -> value
+      _other -> 0
+    end
+  end
+end


### PR DESCRIPTION
This extends the existing `recon.alloc.allocated` metric with a breakdown by allocator. We report two groups of metrics

1. `by_allocator`, which is a break down of the "high level" allocators (`binary_alloc`, `ll_alloc`, etc)
2. `backing_carriers[_size]`/`backing_carriers[_size]`, which is a break down of the "low level" allocators that back the others (both in terms of carriers and size) for `mseg_alloc` and `sys_alloc`.